### PR TITLE
Remove deprecated jQuery event

### DIFF
--- a/jscripts/avatarep.js
+++ b/jscripts/avatarep.js
@@ -1,10 +1,10 @@
 /**
 *@ Autor: Dark Neo
 *@ Fecha: 2017-22-12
-*@ Version: 2.9.8
+*@ Version: 2.9.9
 *@ Contacto: neogeoman@gmail.com
 */
-$(document).on("ready", function(){
+$(function(){
 	var NavaT = 0;						
 	var myTimer;
 	if (typeof lpaname === 'undefined')


### PR DESCRIPTION
`$(document).on( "ready", handler )` is deprecated in v1.8 and removed in 3.0.0. Even `$( document ).ready( handler )` is also deprecated as on date. Please use the recommended method.